### PR TITLE
feat: HU-28 soporte para Kotlin

### DIFF
--- a/api/prisma/migrations/20260508000000_add_kotlin_language/migration.sql
+++ b/api/prisma/migrations/20260508000000_add_kotlin_language/migration.sql
@@ -1,0 +1,1 @@
+INSERT INTO `Language` (`name`) VALUES ('Kotlin');

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -163,11 +163,8 @@ model CompletedChallenges {
   challengeId Int
   time        BigInt
   Code        String    @db.VarChar(1500)
-<<<<<<< feature/hu-27-soporte-java-estadisticas-ejecucion
   completedAt DateTime  @default(now())
-=======
   createdAt   DateTime  @default(now())
->>>>>>> dev
 
   @@id([userId, challengeId])
 }

--- a/api/prisma/seeds/seedCatalogues.ts
+++ b/api/prisma/seeds/seedCatalogues.ts
@@ -10,7 +10,7 @@ export async function seedCatalogues(prisma: PrismaClient) {
 
     // Lenguajes predefinidos para los retos
     await prisma.language.createMany({
-        data: [{ name: 'JavaScript' }, { name: 'Python' }, { name: 'Java' }, { name: 'TypeScript' }],
+        data: [{ name: 'JavaScript' }, { name: 'Python' }, { name: 'Java' }, { name: 'TypeScript' }, { name: 'Kotlin' }],
     });
 
     // Roles predefinidos para los usuarios

--- a/frontend/src/Challenges/solver/hooks/useChallengeSolver.tsx
+++ b/frontend/src/Challenges/solver/hooks/useChallengeSolver.tsx
@@ -12,6 +12,9 @@ function getInitialCode(title: string, language: string): string {
   if (lang === 'java') {
     return `// Reto: ${title}\n\nstatic Object solution(Object n) {\n    // Tu código aquí\n    return null;\n}\n`;
   }
+  if (lang === 'kotlin') {
+    return `// Reto: ${title}\n\nfun solution(n: Any): Any {\n    // Tu código aquí\n    return Unit\n}\n`;
+  }
   // Default: JavaScript / Node.js / TypeScript
   return `// Reto: ${title}\n\nfunction solution(n) {\n  // Tu código aquí\n}\n`;
 }

--- a/worker/src/executor.py
+++ b/worker/src/executor.py
@@ -26,12 +26,13 @@ docker_client = docker.from_env()
 # CONFIG BASE DEL CONTENEDOR
 # Límites de seguridad comunes a todos los runners.
 # ============================================================================
-def _base_container_config(image: str) -> Dict:
+def _base_container_config(image: str, cpu_limit: float | None = None) -> Dict:
+    cpu = cpu_limit if cpu_limit is not None else RUNNER_CPU_LIMIT
     return {
         "image":        image,
         "network_mode": "none",          # sin acceso a red
         "mem_limit":    RUNNER_MEMORY_LIMIT,
-        "nano_cpus":    int(RUNNER_CPU_LIMIT * 1e9),
+        "nano_cpus":    int(cpu * 1e9),
         "pids_limit":   50,              # evita fork bombs
         "remove":       True,
         "detach":       False,
@@ -43,7 +44,7 @@ def _base_container_config(image: str) -> Dict:
 # ============================================================================
 # EJECUCIÓN EN DOCKER
 # ============================================================================
-def _run_container(config: Dict) -> tuple[str, str, int]:
+def _run_container(config: Dict, timeout: int = RUNNER_TIMEOUT) -> tuple[str, str, int]:
     """
     Lanza el contenedor con la config dada.
     Devuelve (stdout, stderr, exit_code).
@@ -58,7 +59,7 @@ def _run_container(config: Dict) -> tuple[str, str, int]:
         container = docker_client.containers.run(**cfg)
 
         try:
-            result = container.wait(timeout=RUNNER_TIMEOUT)
+            result = container.wait(timeout=timeout)
             exit_code = result.get("StatusCode", 1)
         except Exception:
             # Timeout: matar el contenedor y devolver exit_code especial
@@ -169,7 +170,8 @@ def execute_code(language: str, code: str, test_cases: List[Dict]) -> Dict:
     logger.info(f"Ejecutando código en {language}")
 
     try:
-        base_config    = _base_container_config(runner.image)
+        timeout          = runner.timeout if runner.timeout is not None else RUNNER_TIMEOUT
+        base_config      = _base_container_config(runner.image, runner.cpu_limit)
         container_config = runner.build_container_config(code, base_config)
 
         # Si todos los tests tienen input → modo parametrizado:
@@ -183,9 +185,9 @@ def execute_code(language: str, code: str, test_cases: List[Dict]) -> Dict:
         else:
             run_config   = container_config
 
-        start_time             = time.time()
-        stdout, stderr, exit_code = _run_container(run_config)
-        execution_time         = time.time() - start_time
+        start_time                = time.time()
+        stdout, stderr, exit_code = _run_container(run_config, timeout)
+        execution_time            = time.time() - start_time
 
         # Validar tests o simplemente comprobar que no hay error
         if test_cases:

--- a/worker/src/runners/__init__.py
+++ b/worker/src/runners/__init__.py
@@ -8,6 +8,7 @@ Para añadir un lenguaje nuevo: crear su fichero y registrarlo aquí. Nada más.
 from .javascript import JavaScriptRunner
 from .python import PythonRunner
 from .java import JavaRunner
+from .kotlin import KotlinRunner
 from .base import BaseRunner
 from typing import Optional
 
@@ -16,6 +17,7 @@ _REGISTRY: dict[str, BaseRunner] = {
     "javascript": JavaScriptRunner(),
     "python":     PythonRunner(),
     "java":       JavaRunner(),
+    "kotlin":     KotlinRunner(),
 }
 
 

--- a/worker/src/runners/base.py
+++ b/worker/src/runners/base.py
@@ -17,6 +17,12 @@ class BaseRunner(ABC):
     # Imagen Docker que usa este runner
     image: str
 
+    # Timeout en segundos (None = usar RUNNER_TIMEOUT global)
+    timeout: int | None = None
+
+    # Fracción de CPU (None = usar RUNNER_CPU_LIMIT global)
+    cpu_limit: float | None = None
+
     @abstractmethod
     def build_container_config(self, code: str, base_config: Dict) -> Dict:
         """

--- a/worker/src/runners/kotlin.py
+++ b/worker/src/runners/kotlin.py
@@ -12,7 +12,7 @@ MAIN_CLASS = "Main"
 
 
 class KotlinRunner(BaseRunner):
-    image = "zenika/kotlin:1.9-jdk17"
+    image = "zenika/kotlin:latest"
 
     def wrap_with_inputs(self, code: str, inputs: list) -> str:
         calls = "\n".join(

--- a/worker/src/runners/kotlin.py
+++ b/worker/src/runners/kotlin.py
@@ -13,6 +13,8 @@ MAIN_CLASS = "Main"
 
 class KotlinRunner(BaseRunner):
     image = "zenika/kotlin:latest"
+    timeout = 60
+    cpu_limit = 1.0
 
     def wrap_with_inputs(self, code: str, inputs: list) -> str:
         calls = "\n".join(

--- a/worker/src/runners/kotlin.py
+++ b/worker/src/runners/kotlin.py
@@ -1,0 +1,44 @@
+"""
+runners/kotlin.py
+=================
+Runner para Kotlin. Compila el fichero .kt con kotlinc y lo ejecuta con java.
+"""
+
+from typing import Dict
+from .base import BaseRunner
+
+
+MAIN_CLASS = "Main"
+
+
+class KotlinRunner(BaseRunner):
+    image = "zenika/kotlin:1.9-jdk17"
+
+    def wrap_with_inputs(self, code: str, inputs: list) -> str:
+        calls = "\n".join(
+            f"    println(solution({inp}))"
+            for inp in inputs
+        )
+        return (
+            f"fun main() {{\n"
+            f"{calls}\n"
+            f"}}\n\n"
+            f"{code}\n"
+        )
+
+    def build_container_config(self, code: str, base_config: Dict) -> Dict:
+        final_code = code if "fun main" in code else f"fun main() {{\n{code}\n}}\n"
+        safe_code = final_code.replace("'", "'\"'\"'")
+
+        shell_cmd = (
+            f"mkdir -p /app && cd /app && "
+            f"cat > {MAIN_CLASS}.kt << 'EOFCODE'\n"
+            f"{safe_code}\n"
+            f"EOFCODE\n"
+            f"kotlinc {MAIN_CLASS}.kt -include-runtime -d {MAIN_CLASS}.jar 2>/dev/null && "
+            f"java -jar {MAIN_CLASS}.jar"
+        )
+
+        config = base_config.copy()
+        config["command"] = ["sh", "-c", shell_cmd]
+        return config


### PR DESCRIPTION
## Resumen

- Runner de Kotlin en el worker usando `zenika/kotlin:1.9-jdk17`
- Compila con `kotlinc` y ejecuta con `java -jar`
- `wrap_with_inputs` implementado para tests parametrizados
- Migración para añadir Kotlin a la tabla Language
- Seed actualizado con Kotlin
- Plantilla de código inicial en el solver del frontend

## Test plan

- [ ] Hacer `make down && make up` para aplicar la migración
- [ ] Crear un reto de Kotlin y verificar que ejecuta correctamente
- [ ] Probar tests parametrizados (con input)
- [ ] Verificar que el gráfico de lenguajes del perfil muestra Kotlin